### PR TITLE
throw `ArgumentError` instead of `DimensionMismatch` for infinite len

### DIFF
--- a/src/CollectAs.jl
+++ b/src/CollectAs.jl
@@ -308,7 +308,7 @@ module CollectAs
 
     Base.@constprop :aggressive function collect_as(type::ConstructorUnionRough, collection)
         if Base.IteratorSize(collection) === Base.IsInfinite()
-            throw(DimensionMismatch("can't collect infinitely many elements into a finite collection"))
+            throw(ArgumentError("can't collect infinitely many elements into a finite collection"))
         end
         collect_as_common(normalize_type(type), collection)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Aqua: Aqua
     end
 
     @testset "infinite iterator" begin
-        @test_throws DimensionMismatch collect_as(Vector{Int}, Iterators.cycle(3))
+        @test_throws ArgumentError collect_as(Vector{Int}, Iterators.cycle(3))
     end
 
     @testset "`Tuple`" begin


### PR DESCRIPTION
On second thought I don't think `DimensionMismatch` makes much sense here.