### PR TITLE
add back `collect_as` as a higher-level interface for users

### DIFF
--- a/src/Collects.jl
+++ b/src/Collects.jl
@@ -1,5 +1,5 @@
 module Collects
-    export Collect, EmptyIteratorHandling
+    export Collect, EmptyIteratorHandling, collect_as
 
     module TypeUtil
         export is_precise, normalize
@@ -399,5 +399,19 @@ module Collects
             throw(ArgumentError("can't collect infinitely many elements into a finite collection"))
         end
         collect_as_common(collect.empty_iterator_handler, TypeUtil.normalize(type), collection)
+    end
+
+    """
+        collect_as(output_type::Type, collection; empty_iterator_handler)
+
+    Collect `collection` into a collection of type `output_type`. The optional keyword
+    argument `empty_iterator_handler` may be used to control the behavior for when
+    `collection` is empty.
+
+    Do not add any method. This function just forwards to [`Collect`](@ref).
+    """
+    Base.@constprop :aggressive function collect_as(::Type{T}, collection; empty_iterator_handler::EIH = just_throws) where {T, EIH}
+        c = Collect(; empty_iterator_handler)
+        c(T, collection)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Collects
 using Test
 
 @testset "collect_as: $collect_as" for collect_as ∈ (
+    collect_as,
     Collect(),
     Collect(; empty_iterator_handler = EmptyIteratorHandling.just_throws),
     Collect(; empty_iterator_handler = EmptyIteratorHandling.may_use_type_inference),
@@ -67,7 +68,7 @@ end
 @testset "type inference" begin
     iterator = Iterators.map((x -> 0.5 * x), 1:0)
     (Float64 === Collects.EmptyIteratorHandling.@default_eltype iterator) &&
-    @test [] == (@inferred Collect(; empty_iterator_handler = EmptyIteratorHandling.may_use_type_inference)(Vector, iterator))::Vector{Float64}
+    @test [] == (@inferred collect_as(Vector, iterator; empty_iterator_handler = EmptyIteratorHandling.may_use_type_inference))::Vector{Float64}
 end
 
 module TestAqua


### PR DESCRIPTION
Thanks for Eric Hanson for the suggestion.